### PR TITLE
bugfix: use the actual pid from the pidlist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,8 @@ function shutdown() {
     trap "" SIGINT
 
     for single in $pidlist; do
-        if ! kill -0 $pidlist 2>/dev/null; then
-            wait $pidlist
+        if ! kill -0 $single 2>/dev/null; then
+            wait $single
             exitcode=$?
         fi
     done


### PR DESCRIPTION
We are cycling through a list of pids to deal with them one by one. However,
the code dealing with the actual list instead of each item.