### PR TITLE
Update to Alpine 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
* Update Docker image to use Alpine 3.14 released in 2021-06-15

Alpine 3.14: https://alpinelinux.org/posts/Alpine-3.14.0-released.html