### PR TITLE
chore: upgrade alpine base image to 3.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ arch:
   - arm64
 
 os: linux
+dist: focal
 
 before_install:
   - curl -fsSL https://get.docker.com | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL maintainer="team@appwrite.io"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN \
     apk upgrade --available && \
     apk add --no-cache \
         bash \
-        clamav-libunrar \
-        clamav \
+        clamav-libunrar=0.104.3-r0 \
+        clamav=0.104.3-r0 \
         rsyslog \
         wget && \
     rm -rf /var/cache/apk/*

--- a/conf/freshclam.conf
+++ b/conf/freshclam.conf
@@ -38,19 +38,3 @@ DatabaseMirror database.clamav.net
 # Send the RELOAD command to clamd.
 # Default: no
 NotifyClamd /etc/clamav/clamd.conf
-
-# This option enables support for Google Safe Browsing. When activated for
-# the first time, freshclam will download a new database file
-# (safebrowsing.cvd) which will be automatically loaded by clamd and
-# clamscan during the next reload, provided that the heuristic phishing
-# detection is turned on. This database includes information about websites
-# that may be phishing sites or possible sources of malware. When using this
-# option, it's mandatory to run freshclam at least every 30 minutes.
-# Freshclam uses the ClamAV's mirror infrastructure to distribute the
-# database and its updates but all the contents are provided under Google's
-# terms of use.
-# See https://transparencyreport.google.com/safe-browsing/overview
-# and https://www.clamav.net/documents/safebrowsing for more information.
-# Default: no
-SafeBrowsing yes
-


### PR DESCRIPTION
- use `alpine:3.15` as base image
- use specific version for clamav packages -> `0.104.3-r0`
- use `focal` dist in travis

Related: https://github.com/appwrite/appwrite/issues/3311